### PR TITLE
fix(plugin): recursive optimisation of pattern matches in attributes/…

### DIFF
--- a/Partas.Solid.FablePlugin/Plugin.fs
+++ b/Partas.Solid.FablePlugin/Plugin.fs
@@ -25,6 +25,76 @@ module internal rec AST =
     module Utils = Patterns
     [<AutoOpen>]
     module AttributesAndProperties =
+        let private (|MatchValueReplacerFeedback|) (ctx: PluginContext) (ident: Expr): Expr -> Expr list = function
+            | expr ->
+                if ctx.Flags.HasFlag(ComponentFlag.SkipCEOptimisation)
+                then [ expr ]
+                else
+                match [ expr ] with
+                | MatchValueReplacer ctx ident exprs -> exprs
+
+        /// This is essentially a copy pasta of the ValueUnroller. For the sake of preventing double
+        /// node traversal we're mashing that into this until we can start measuring costs in performance.
+        let private (|MatchValueReplacer|) (ctx: PluginContext) (ident: Expr): Expr list -> Expr list = function
+            | [] -> []
+            | Sequential (MatchValueReplacer ctx ident exprs) :: rest ->
+                exprs @ rest
+            | expr :: MatchValueReplacer ctx ident rest ->
+                match expr with
+                | IdentExpr({ Name = Utils.StartsWith "matchValue" }) ->
+                    ident :: rest
+                | Call(Import({ Selector = (Utils.StartsWith "toArray" | Utils.StartsWith "toList") }, Any, None), { Args = MatchValueReplacer ctx ident exprs }, typ, range) ->
+                    Value(NewArray(ArrayValues exprs, Any, ArrayKind.MutableArray), range) :: rest
+                | Call(Import({ Selector = Utils.StartsWith "delay" }, Any, None), { Args = MatchValueReplacer ctx ident exprs }, typ, range) ->
+                    exprs @ rest
+                | Lambda({ Name = Utils.StartsWith "unitVar"; IsCompilerGenerated = true }, MatchValueReplacerFeedback ctx ident exprs, range) ->
+                    exprs @ rest
+                | Call(Import({ Selector = Utils.StartsWith "append" }, Any, None), { Args = MatchValueReplacer ctx ident exprs }, typ, range) ->
+                    exprs @ rest
+                | Call(Import({Selector = Utils.StartsWith "singleton"}, Any, None), { Args = value :: MatchValueReplacer ctx ident exprs }, typ, range) ->
+                    exprs @ (value :: rest)
+                | Call(Import({ Selector = Utils.StartsWith "empty"; Path = Utils.EndsWith "Seq.js" }, Any, None), { Args = []; GenericArgs = typ :: _ }, _, _) ->
+                    Value(ValueKind.Null(typ), None) :: rest
+                | Call(callee, ({ Args = MatchValueReplacer ctx ident exprs } as callInfo), typ, range) ->
+                    Call(callee, { callInfo with Args = exprs }, typ, range) :: rest
+                // If we hit this path, then we are likely matching on a new identifier
+                | Let({ Name = Utils.StartsWith "matchValue" } as identifier, body, value) ->
+                    match body with
+                    // If it is a property, we will preform the replacer with the new identifier
+                    | PropertyGetter ctx prop ->
+                        let newIdent = propGetter prop
+                        match value with
+                        // reduction with new identifier
+                        | MatchValueReplacerFeedback ctx newIdent newValue ->
+                            newValue @ rest
+                    | MatchValueReplacerFeedback ctx ident bodyExprs ->
+                        match value with MatchValueReplacerFeedback ctx ident valueExprs ->
+                            Let(identifier, AstUtils.Sequential bodyExprs, AstUtils.Sequential valueExprs) :: rest
+
+                | Let({ Name = Utils.StartsWith "matchValue" } as ident, MatchValueReplacerFeedback ctx ident body, MatchValueReplacerFeedback ctx ident value) ->
+                    Let(ident, AstUtils.Sequential body, AstUtils.Sequential value) :: rest
+                | TypeCast(MatchValueReplacerFeedback ctx ident exprs, typ) ->
+                    exprs @ rest
+                | IfThenElse(MatchValueReplacerFeedback ctx ident guardExprs, MatchValueReplacerFeedback ctx ident thenExprs, MatchValueReplacerFeedback ctx ident elseExprs, range) ->
+                    IfThenElse(AstUtils.Sequential guardExprs, AstUtils.Sequential thenExprs, AstUtils.Sequential elseExprs, range) :: rest
+                | DecisionTree(MatchValueReplacerFeedback ctx ident expr, targets) ->
+                    let targets =
+                        targets
+                        |> List.map(fun (idents,expr) ->
+                            idents,
+                            match expr with
+                            | MatchValueReplacerFeedback ctx ident result ->
+                                AstUtils.Sequential result
+                            )
+                    DecisionTree(AstUtils.Sequential expr, targets) :: rest
+                | Operation (Binary (binaryOperator, MatchValueReplacerFeedback ctx ident left, MatchValueReplacerFeedback ctx ident right), tags, ``type``, sourceLocationOption) ->
+                    Operation(Binary(binaryOperator, AstUtils.Sequential left, AstUtils.Sequential right), tags, ``type``, sourceLocationOption) :: rest
+                | Operation (OperationKind.Logical (binaryOperator, MatchValueReplacerFeedback ctx ident left, MatchValueReplacerFeedback ctx ident right), tags, ``type``, sourceLocationOption) ->
+                    Operation(Logical(binaryOperator, AstUtils.Sequential left, AstUtils.Sequential right), tags, ``type``, sourceLocationOption) :: rest
+                | Operation (OperationKind.Unary (binaryOperator, MatchValueReplacerFeedback ctx ident unaryExprs), tags, ``type``, sourceLocationOption) ->
+                    Operation(Unary(binaryOperator, AstUtils.Sequential unaryExprs), tags, ``type``, sourceLocationOption) :: rest
+                | expr -> expr :: rest
+
         let (|ValueUnrollerFeedback|) (ctx: PluginContext) (expr: Expr): Expr list =
             if ctx |> PluginContext.hasFlag ComponentFlag.SkipCEOptimisation
             then [ expr ]
@@ -57,10 +127,39 @@ module internal rec AST =
                     Value(ValueKind.Null(typ), None) :: rest
                 | Call(callee, ({ Args = ValueUnroller ctx exprs } as callInfo), typ, range) ->
                     Call(callee, { callInfo with Args = exprs }, typ, range) :: rest
+                | Let({ Name = Utils.StartsWith "matchValue" } as ident, body, value) ->
+                    match body with
+                    | PropertyGetter ctx prop ->
+                        let newIdent = propGetter prop
+                        match value with
+                        | MatchValueReplacerFeedback ctx newIdent newValue ->
+                            newValue @ rest
+                    | ValueUnrollerFeedback ctx bodyExprs ->
+                        match value with ValueUnrollerFeedback ctx valueExprs ->
+                            Let(ident, AstUtils.Sequential bodyExprs, AstUtils.Sequential valueExprs) :: rest
+
+                | Let({ Name = Utils.StartsWith "matchValue" } as ident, ValueUnrollerFeedback ctx body, ValueUnrollerFeedback ctx value) ->
+                    Let(ident, AstUtils.Sequential body, AstUtils.Sequential value) :: rest
                 | TypeCast(ValueUnrollerFeedback ctx exprs, typ) ->
                     exprs @ rest
                 | IfThenElse(ValueUnrollerFeedback ctx guardExprs, ValueUnrollerFeedback ctx thenExprs, ValueUnrollerFeedback ctx elseExprs, range) ->
-                    IfThenElse(Sequential guardExprs, Sequential thenExprs, Sequential elseExprs, range) :: rest
+                    IfThenElse(AstUtils.Sequential guardExprs, AstUtils.Sequential thenExprs, AstUtils.Sequential elseExprs, range) :: rest
+                | DecisionTree(ValueUnrollerFeedback ctx expr, targets) ->
+                    let targets =
+                        targets
+                        |> List.map(fun (idents,expr) ->
+                            idents,
+                            match expr with
+                            | ValueUnrollerFeedback ctx result ->
+                                AstUtils.Sequential result
+                            )
+                    DecisionTree(AstUtils.Sequential expr, targets) :: rest
+                | Operation (Binary (binaryOperator, ValueUnrollerFeedback ctx left, ValueUnrollerFeedback ctx right), tags, ``type``, sourceLocationOption) ->
+                    Operation(Binary(binaryOperator, AstUtils.Sequential left, AstUtils.Sequential right), tags, ``type``, sourceLocationOption) :: rest
+                | Operation (OperationKind.Logical (binaryOperator, ValueUnrollerFeedback ctx left, ValueUnrollerFeedback ctx right), tags, ``type``, sourceLocationOption) ->
+                    Operation(Logical(binaryOperator, AstUtils.Sequential left, AstUtils.Sequential right), tags, ``type``, sourceLocationOption) :: rest
+                | Operation (OperationKind.Unary (binaryOperator, ValueUnrollerFeedback ctx unaryExprs), tags, ``type``, sourceLocationOption) ->
+                    Operation(Unary(binaryOperator, AstUtils.Sequential unaryExprs), tags, ``type``, sourceLocationOption) :: rest
                 | expr -> expr :: rest
 
 
@@ -109,7 +208,7 @@ module internal rec AST =
         /// comes BEFORE the PropertySetter recognizer. The Setter is greedy, and will
         /// nullify expressions that are attribute expressions which involve the props ident
         /// </remarks>
-        let private (|PropertyGetter|_|) (ctx: PluginContext) = function
+        let private (|PropertyGetter|_|) (ctx: PluginContext): Expr -> string option = function
             | Get(
                 expr = (
                     // Defined locally

--- a/Partas.Solid.FablePlugin/Utils.fs
+++ b/Partas.Solid.FablePlugin/Utils.fs
@@ -11,6 +11,12 @@ type AstUtilHelpers =
 open type AstUtilHelpers
 
 type AstUtils =
+
+    /// Creates a unit constant expression
+    static member inline Unit = Expr.Value (ValueKind.UnitConstant, range)
+    /// Creates a null constant expression
+    static member inline Null = Expr.Value (ValueKind.Null any, range)
+
     /// Creates a string constant expression
     static member inline Value(stringValue: string) =
         Expr.Value (ValueKind.StringConstant stringValue, range)
@@ -35,6 +41,14 @@ type AstUtils =
         nodes
         |> Array.toList
         |> Sequential
+
+    /// Will check if expr list is either empty, and emit a null; a single expr long, and emit that expr; else
+    /// wraps the expressions in a Sequential DU
+    static member inline Sequential(exprList: Expr list) : Expr =
+        match exprList with
+        | [] -> AstUtils.Unit
+        | [ expr ] -> expr
+        | _ -> Sequential exprList
 
     /// Creates a user import expression with the selector and path
     static member inline Import(selector: string, path: string) =
@@ -70,10 +84,6 @@ type AstUtils =
         let typ = defaultArg typ any
         Expr.Call (callee, info, typ, range)
 
-    /// Creates a unit constant expression
-    static member inline Unit = Expr.Value (ValueKind.UnitConstant, range)
-    /// Creates a null constant expression
-    static member inline Null = Expr.Value (ValueKind.Null any, range)
 
     /// Creates an anonymous record from the list of string (field) expr (value) tuples
     static member inline Object(pairs: (string * Expr) list) =

--- a/Partas.Solid.Tests.Plugin/Compiled/Partas.Solid.Tests.Plugin.Compiled.fsproj
+++ b/Partas.Solid.Tests.Plugin/Compiled/Partas.Solid.Tests.Plugin.Compiled.fsproj
@@ -93,6 +93,8 @@
         <Compile Include="SolidCases\SolidComponentAsTagValues\SolidComponentAsTagValuesTypes.fs" />
         <Compile Include="SolidCases\SolidComponentAsTagValues\SolidComponentAsTagValues.fs" />
         <Content Include="SolidCases\SolidComponentAsTagValues\SolidComponentAsTagValues.expected" />
+        <Compile Include="SolidCases\ValueUnrollerDecisionTree\ValueUnrollerDecisionTree.fs" />
+        <Content Include="SolidCases\ValueUnrollerDecisionTree\ValueUnrollerDecisionTree.expected" />
 <!--        <Content Include="Spec\Components.fs" />-->
     </ItemGroup>
 

--- a/Partas.Solid.Tests.Plugin/Compiled/SolidCases/OperatorsInProps/OperatorsInProps.expected
+++ b/Partas.Solid.Tests.Plugin/Compiled/SolidCases/OperatorsInProps/OperatorsInProps.expected
@@ -1,3 +1,4 @@
+
 import { Match, Switch, splitProps, mergeProps, onCleanup, createEffect, createSignal, useContext, createContext } from "solid-js";
 import { twMerge } from "tailwind-merge";
 import { clsx } from "clsx";
@@ -76,8 +77,8 @@ export function Sidebar(props) {
             </Sheet>
         </Match>
         <Match when={!isMobile()}>
-            <div class={twMerge(clsx(["a1", "a2", "a3", ((PARTAS_LOCAL.variant === "floating") ? (true) : (PARTAS_LOCAL.variant === "inset")) ? ("?a1") : ("?a2")]))} />
-            <div class={twMerge(clsx(["b1", (PARTAS_LOCAL.side === "left") ? ("?b1") : ("?b2"), ((PARTAS_LOCAL.variant === "floating") ? (true) : (PARTAS_LOCAL.variant === "inset")) ? ("?b3") : ("?b4"), PARTAS_LOCAL.class]))}
+            <div class={twMerge(clsx(["a1", "a2", "a3", ((PARTAS_LOCAL.variant === "floating") ? true : (PARTAS_LOCAL.variant === "inset")) ? "?a1" : "?a2"]))} />
+            <div class={twMerge(clsx(["b1", (PARTAS_LOCAL.side === "left") ? "?b1" : "?b2", ((PARTAS_LOCAL.variant === "floating") ? true : (PARTAS_LOCAL.variant === "inset")) ? "?b3" : "?b4", PARTAS_LOCAL.class]))}
                 {...PARTAS_OTHERS} bool:n$={false}>
                 <div class="classend"
                     data-sidebar="sidebar">

--- a/Partas.Solid.Tests.Plugin/Compiled/SolidCases/ValueUnrollerDecisionTree/ValueUnrollerDecisionTree.expected
+++ b/Partas.Solid.Tests.Plugin/Compiled/SolidCases/ValueUnrollerDecisionTree/ValueUnrollerDecisionTree.expected
@@ -1,0 +1,19 @@
+
+import { twMerge } from "tailwind-merge";
+import { clsx } from "clsx";
+import { splitProps } from "solid-js";
+
+export function Lib_cn_Z35CD86D0(classes) {
+    return twMerge(clsx(classes));
+}
+
+export function ValueUnrollTest(props) {
+    const [PARTAS_LOCAL, PARTAS_OTHERS] = splitProps(props, []);
+    return <div class={Lib_cn_Z35CD86D0(["bg-primary", (PARTAS_LOCAL.variant === "black") ? "black" : ((PARTAS_LOCAL.variant === "green") ? "green" : "brown")])} />;
+}
+
+export function ValueUnrollNestedTest(props) {
+    const [PARTAS_LOCAL, PARTAS_OTHERS] = splitProps(props, []);
+    return <div class={Lib_cn_Z35CD86D0(["bg-primary", (PARTAS_LOCAL.variant === "black") ? ((props.altVariant === "blue") ? "black & blue" : "black") : ((PARTAS_LOCAL.variant === "green") ? ((PARTAS_LOCAL.altVariant === "orange") ? "orange & blue" : ((PARTAS_LOCAL.altVariant === "yellow") ? "yellow & blue" : "green & blue")) : "brown")])} />;
+}
+

--- a/Partas.Solid.Tests.Plugin/Compiled/SolidCases/ValueUnrollerDecisionTree/ValueUnrollerDecisionTree.fs
+++ b/Partas.Solid.Tests.Plugin/Compiled/SolidCases/ValueUnrollerDecisionTree/ValueUnrollerDecisionTree.fs
@@ -1,0 +1,78 @@
+﻿module Partas.Solid.Tests.Plugin.Compiled.SolidCases.ValueUnrollerDecisionTree.ValueUnrollerDecisionTree
+
+open Partas.Solid
+open Fable.Core
+open Fable.Core.JS
+open Fable.Core.JsInterop
+
+[<Erase>]
+type Lib =
+    [<ImportMember("tailwind-merge")>]
+    static member twMerge(classes: string) : string = jsNative
+
+    [<ImportMember("clsx")>]
+    static member clsx(classes: obj) : string = jsNative
+
+    [<CompiledName("cn")>]
+    static member cn(classes: string array) : string =
+        classes
+        |> Lib.clsx
+        |> Lib.twMerge
+
+[<StringEnum>]
+type Variant =
+    | Black
+    | Brown
+    | Green
+
+[<Erase>]
+type ValueUnrollTest() =
+    interface RegularNode
+
+    [<DefaultValue>]
+    val mutable variant: Variant
+
+    [<SolidTypeComponent>]
+    member props.__ =
+        div (
+            class' =
+                Lib.cn
+                    [| "bg-primary"
+                       match props.variant with
+                       | Brown -> "brown"
+                       | Black -> "black"
+                       | Green -> "green" |]
+        )
+
+[<StringEnum>]
+type AltVariant =
+    | Blue
+    | Orange
+    | Yellow
+
+[<Erase>]
+type ValueUnrollNestedTest() =
+    interface RegularNode
+
+    [<DefaultValue>]
+    val mutable variant: Variant
+
+    [<DefaultValue>]
+    val mutable altVariant: AltVariant
+
+    [<SolidTypeComponent>]
+    member props.__ =
+        div (
+            class' =
+                Lib.cn
+                    [| "bg-primary"
+                       match props.variant with
+                       | Brown -> "brown"
+                       | Black when props.altVariant = Blue -> "black & blue"
+                       | Black -> "black"
+                       | Green ->
+                           match props.altVariant with
+                           | Blue -> "green & blue"
+                           | Orange -> "orange & blue"
+                           | Yellow -> "yellow & blue" |]
+        )

--- a/Partas.Solid.Tests.Plugin/Tests.fs
+++ b/Partas.Solid.Tests.Plugin/Tests.fs
@@ -94,7 +94,9 @@ let SolidCases =
           "ChildLambdaProvider"
           |> runSolidCase "ChildLambdaProvider interfaces"
           "SolidComponentAsTagValues"
-          |> runSolidCase "SolidComponent let bindings as TagValues" ]
+          |> runSolidCase "SolidComponent let bindings as TagValues"
+          "ValueUnrollerDecisionTree"
+          |> runSolidCase "Decision Trees in arrays do not spawn singleton instructions" ]
 
 [<Tests>]
 let AttributeCases =


### PR DESCRIPTION
…properties

Also fixed the spawning of `singleton` operations in pattern matches.

Previously, reactivity of solid-js would be broken when pattern matching on a property directly. This is because the generation of the expression `(matchValue = props.___, matchValue === ____ ? ____ : ___)` et al would not be caught by the solid-js library/compiler.

For this reason, we remove this CE optimisation when pattern matching on property getters only.

This behaviour can be disabled using the SkipCEOptimisation component flag.

This constitutes a 'fix' more than a breaking change.